### PR TITLE
fix: separate File-based logic to avoid Netlify build error

### DIFF
--- a/src/services/achievements/achievements.service.ts
+++ b/src/services/achievements/achievements.service.ts
@@ -7,7 +7,7 @@ import {
   PayloadAssignAchievement,
 } from '@/models/schema';
 import { API_PAYLOAD, API_RESPONSE, API_SINGLE_RESPONSE } from '@/models/types';
-import { axiosErrorHandler, ParseToFormData } from '@/utils/axios';
+import { axiosErrorHandler, ParseToFormData } from '@/utils';
 import { valuesWithData } from '@/utils/objects';
 
 export const ListAchievementService = async (

--- a/src/services/category/category.service.ts
+++ b/src/services/category/category.service.ts
@@ -2,7 +2,7 @@ import { API_HOPE_PROTECTED, defaultPayload } from '@/config';
 import { API } from '@/constants/ApiUrls';
 import { CategoryPictogram, PayloadCategory } from '@/models/schema';
 import { API_PAYLOAD, API_RESPONSE, API_SINGLE_RESPONSE } from '@/models/types';
-import { axiosErrorHandler, ParseToFormData } from '@/utils/axios';
+import { axiosErrorHandler, ParseToFormData } from '@/utils';
 import { valuesWithData } from '@/utils/objects';
 
 export const ListCategoryPictogramService = async (

--- a/src/services/pictogram/pictogram.service.ts
+++ b/src/services/pictogram/pictogram.service.ts
@@ -2,7 +2,7 @@ import { API_HOPE_PROTECTED, defaultPayload } from '@/config';
 import { API } from '@/constants/ApiUrls';
 import { PayloadPictogram, SinglePictogram } from '@/models/schema';
 import { API_PAYLOAD, API_RESPONSE, API_SINGLE_RESPONSE } from '@/models/types';
-import { axiosErrorHandler, ParseToFormData } from '@/utils/axios';
+import { axiosErrorHandler, ParseToFormData } from '@/utils';
 import { valuesWithData } from '@/utils/objects';
 
 export const ListPictogramsService = async (

--- a/src/services/user/user.service.ts
+++ b/src/services/user/user.service.ts
@@ -18,7 +18,7 @@ import {
   UpdateTutorTherapistResponse,
 } from '@/models/schema';
 import { API_PAYLOAD, API_RESPONSE, API_SINGLE_RESPONSE } from '@/models/types';
-import { axiosErrorHandler, ParseToFormData } from '@/utils/axios';
+import { axiosErrorHandler, ParseToFormData } from '@/utils';
 import { valuesWithData } from '@/utils/objects';
 
 /*

--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -1,8 +1,5 @@
 import { API_RESPONSE, I_VALIDATION_ERRORS } from '@/models/types';
-import { UploadFile } from 'antd';
 import axios, { AxiosError } from 'axios';
-
-const INPUT_FILE_KEY = 'imageFile';
 
 export interface CustomError extends Error {
   statusCode?: number;
@@ -29,43 +26,4 @@ export const axiosErrorHandler = (
   }
 
   throw err;
-};
-
-export const ParseToFormData = (payload: Record<string, unknown>): FormData => {
-  try {
-    const form = new FormData();
-
-    Object.entries(payload).forEach(([key, value]) => {
-      if (value === undefined || value === null) {
-        return;
-      }
-
-      if (key === INPUT_FILE_KEY) {
-        const fileList = value as UploadFile[];
-        const firstFile = fileList[0];
-        if (firstFile?.originFileObj) {
-          form.append(key, firstFile.originFileObj as Blob);
-        }
-        return;
-      }
-
-      if (Array.isArray(value)) {
-        value.forEach((item) => {
-          form.append(`${String(key)}[]`, item.toString());
-        });
-        return;
-      }
-
-      if (value instanceof Blob || value instanceof File) {
-        form.append(String(key), value);
-        return;
-      }
-
-      form.append(String(key), value.toString());
-    });
-
-    return form;
-  } catch (error) {
-    throw error;
-  }
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,2 @@
+export * from './parseToFormData';
+export * from './axios';

--- a/src/utils/parseToFormData.ts
+++ b/src/utils/parseToFormData.ts
@@ -1,0 +1,42 @@
+import { UploadFile } from 'antd';
+
+const INPUT_FILE_KEY = 'imageFile';
+
+export const ParseToFormData = (payload: Record<string, unknown>): FormData => {
+  try {
+    const form = new FormData();
+
+    Object.entries(payload).forEach(([key, value]) => {
+      if (value === undefined || value === null) {
+        return;
+      }
+
+      if (key === INPUT_FILE_KEY) {
+        const fileList = value as UploadFile[];
+        const firstFile = fileList[0];
+        if (firstFile?.originFileObj) {
+          form.append(key, firstFile.originFileObj as Blob);
+        }
+        return;
+      }
+
+      if (Array.isArray(value)) {
+        value.forEach((item) => {
+          form.append(`${String(key)}[]`, item.toString());
+        });
+        return;
+      }
+
+      if (value instanceof Blob || value instanceof File) {
+        form.append(String(key), value);
+        return;
+      }
+
+      form.append(String(key), value.toString());
+    });
+
+    return form;
+  } catch (error) {
+    throw error;
+  }
+};


### PR DESCRIPTION
## Description

The utils/axios file previously included two functions:

- axiosErrorHandler: used in service files for centralized HTTP error handling.
- parseToFormData: used the File object, which is only available in the browser.

This caused a ReferenceError: File is not defined during the build process on Netlify, since utils/axios was being imported in server-side code.

To fix this:

- axiosErrorHandler remains in utils/axios.
- parseToFormData has been moved to a new file: utils/parseToFormData, isolating logic that depends on browser-only APIs.

This refactor ensures that only server-safe code is imported where needed, preventing runtime and build-time errors.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] This change requires a documentation update
- [ ] Other (please describe): 

## How Has This Been Tested?

Describe the tests you've run to verify the changes. Provide instructions for reproduction and indicate any relevant details for your test setup.

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in areas hard to understand.
- [ ] I have made the corresponding changes to the documentation.
- [ ] My changes do not generate new warnings.
- [ ] I have added tests that prove my solution is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] All dependent changes have been merged and published in subsequent modules.
- [ ] I have reviewed my code and corrected any spelling mistakes.
